### PR TITLE
Fix filesets output separator.

### DIFF
--- a/src/main/java/capsule/CapsuleMojo.java
+++ b/src/main/java/capsule/CapsuleMojo.java
@@ -441,7 +441,7 @@ public class CapsuleMojo extends AbstractMojo {
 
 				for (final String include : fileSet.includes) {
 					final FileInputStream fin = new FileInputStream(new File(directory, include));
-					addToJar(fileSet.outputDirectory + "/" + include, fin, jar);
+					addToJar(fileSet.outputDirectory + include, fin, jar);
 				}
 			}
 		}


### PR DESCRIPTION
Sorry, the separator logic was incorrect and resulted in a duplicate separator in the output path (eg. "directory//file.txt").  Harmless enough, but if you leave the output directory unspecified, that'd result in "/file.txt" instead of "file.txt"  I think jar might actually handle that "correctly," but worth fixing.
